### PR TITLE
[FIXED JENKINS-32659] Add support for Cloudbees Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.iml
+*.iws
+*.ipr
+
+.idea
+
+target
+out
+work
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.480</version>
     </parent>
 
     <artifactId>startup-trigger-plugin</artifactId>
@@ -44,6 +44,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jvnet/hudson/plugins/triggers/startup/HudsonComputerListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/triggers/startup/HudsonComputerListener.java
@@ -41,9 +41,9 @@ public class HudsonComputerListener extends ComputerListener implements Serializ
         Node node = c.getNode();
         if (node != null) {
             listener.getLogger().println("[StartupTrigger] - Scanning jobs for node " + getNodeName(node));
-            List<TopLevelItem> items = Hudson.getInstance().getItems();
-            for (TopLevelItem item : items) {
-                processAndScheduleIfNeeded(item, c, listener);
+            List<AbstractProject> jobs = Hudson.getInstance().getAllItems(AbstractProject.class);
+            for (AbstractProject job : jobs) {
+                processAndScheduleIfNeeded(job, c, listener);
             }
         }
     }
@@ -56,14 +56,8 @@ public class HudsonComputerListener extends ComputerListener implements Serializ
         return nodeName;
     }
 
-    private void processAndScheduleIfNeeded(TopLevelItem item, Computer c, TaskListener listener) {
-
-        if (!(item instanceof AbstractProject)) {
-            return;
-        }
-        AbstractProject<?, ?> project = (AbstractProject) item;
-
-        HudsonStartupTrigger startupTrigger = project.getTrigger(HudsonStartupTrigger.class);
+    private void processAndScheduleIfNeeded(AbstractProject project, Computer c, TaskListener listener) {
+        HudsonStartupTrigger startupTrigger = (HudsonStartupTrigger) project.getTrigger(HudsonStartupTrigger.class);
         if (startupTrigger == null) {
             return;
         }

--- a/src/test/java/org/jvnet/hudson/plugins/triggers/startup/HudsonComputerListenerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/triggers/startup/HudsonComputerListenerTest.java
@@ -1,0 +1,79 @@
+package org.jvnet.hudson.plugins.triggers.startup;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, Schneider Electric
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.FreeStyleProject;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+
+public class HudsonComputerListenerTest extends HudsonTestCase {
+    public void testRootJob() throws Exception {
+        // Create job with startup trigger
+        FreeStyleProject job = createFreeStyleProject("job");
+        job.addTrigger(new HudsonStartupTrigger("slave0", null));
+
+        // Create slave which node name will be slave0
+        createOnlineSlave();
+
+        // Wait for the completion of the build
+        waitUntilNoActivity();
+
+        assertTrue(job.getLastSuccessfulBuild().number == 1);
+    }
+
+    public void testFolderJob() throws Exception {
+        // Create one level folder and a job with startup trigger
+        Folder folder = this.hudson.createProject(Folder.class, "folder1");
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        job.addTrigger(new HudsonStartupTrigger("slave0", null));
+
+        // Create slave which node name will be slave0
+        createOnlineSlave();
+
+        // Wait for the completion of the build
+        waitUntilNoActivity();
+
+        assertTrue(job.getLastSuccessfulBuild().number == 1);
+    }
+
+    public void testSubFolderJob() throws Exception {
+        // Create two level folder and a job with startup trigger
+        Folder folder1 = this.hudson.createProject(Folder.class, "folder1");
+        Folder folder2 = folder1.createProject(Folder.class, "folder2");
+
+        FreeStyleProject job = folder2.createProject(FreeStyleProject.class, "job");
+        job.addTrigger(new HudsonStartupTrigger("slave0", null));
+
+
+        // Create slave which node name will be slave0
+        createOnlineSlave();
+
+        // Wait for the completion of the build
+        waitUntilNoActivity();
+
+        assertTrue(job.getLastSuccessfulBuild().number == 1);
+    }
+}


### PR DESCRIPTION
Current version only support jobs which are at the root level of Jenkins. This pull request enables launch of job in any level of subfolder. I tested it against Jenkins 1.596.3 and 1.646.